### PR TITLE
Cleanup the code and make it more typesafe

### DIFF
--- a/_README.MD
+++ b/_README.MD
@@ -1548,12 +1548,12 @@ const ethereumNode: EthereumNode = {
 
 const result = await checkDAProof(PROOF_ID, ethereumNode);
 if (result.isSuccess()) {
-    console.log('proof valid', result.successResult!)
+    console.log('proof valid', result.successResult)
     return; // all is well!
 }
 
 // it failed!
-console.error('proof invalid do something', result.failure!)
+console.error('proof invalid do something', result.failure)
 ```
 
 ### Server usage
@@ -1572,12 +1572,12 @@ const ethereumNode: EthereumNode = {
 
 const result = await checkDAProof(PROOF_ID, ethereumNode);
 if (result.isSuccess()) {
-    console.log('proof valid', result.successResult!)
+    console.log('proof valid', result.successResult)
     return; // all is well!
 }
 
 // it failed!
-console.error('proof invalid do something', result.failure!)
+console.error('proof invalid do something', result.failure)
 ```
 
 #### startDAVerifierNode

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "debug:playground:workers": "node lib/__PLAYGROUND__/main.js",
     "generate": "graphql-codegen",
     "test": "env-cmd -f .env jest",
-    "lint": "pnpm run prettier && pnpm run tsc --noEmit",
-    "lint:fix": "pnpm run prettier:fix && pnpm run eslint",
+    "lint": "pnpm run prettier && pnpm run eslint && pnpm run tsc",
+    "lint:fix": "pnpm run prettier:fix && pnpm run eslint --fix && pnpm run tsc",
     "prettier:fix": "prettier --write .",
     "prettier": "prettier --check .",
+    "tsc": "tsc --noEmit",
     "prepublishOnly": "pnpm run build",
     "publish": "pnpm publish --access public",
     "preinstall": "npx only-allow pnpm"

--- a/playground-browser/src/App.tsx
+++ b/playground-browser/src/App.tsx
@@ -15,12 +15,12 @@ const ethereumNode: EthereumNode = {
 const check = async () => {
   const result = await checkDAProof('VlPh9JdZ2SNcnWaqgHFRfycT8xpuoX2MR5LnI95f87w', ethereumNode);
   if (result.isSuccess()) {
-    console.log('proof valid', result.successResult!);
+    console.log('proof valid', result.successResult);
     return;
   }
 
   // it failed!
-  console.error('proof invalid do something', result.failure!);
+  console.error('proof invalid do something', result.failure);
 
   console.log(ethereumNode);
 };

--- a/src/__TESTS__/publications/publication.base.test.ts
+++ b/src/__TESTS__/publications/publication.base.test.ts
@@ -80,7 +80,7 @@ describe('publication base', () => {
         '0x56b1108c5c15aa3344fe87aa0a5b2d827625de8a7283e5cdb21088e30d49cd4203088a336bc9c0fac5cca0a84af84b7227be24e0bef55ece423f25015e807cd71b'
       );
 
-      expect(result.successResult!).toEqual('0xD8c789626CDb461ec9347f26DDbA98F9383aa457');
+      expect(result.successResult).toEqual('0xD8c789626CDb461ec9347f26DDbA98F9383aa457');
     });
   });
 });

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -111,14 +111,6 @@ export const createTimeoutPromise = (
   return { promise, timeoutId: timeoutIdWrapper.timeoutId };
 };
 
-/**
- *  Return if the processing doing this is native node and not a browser
- *  @deprecated Client now has a separate code path to avoid increasing bundle size
- */
-export const isNativeNode = (): boolean => {
-  return typeof window === 'undefined';
-};
-
 type AsyncFunction<T> = () => Promise<T>;
 
 export interface RetryWithTimeoutOptions {

--- a/src/evm/ethereum.ts
+++ b/src/evm/ethereum.ts
@@ -32,7 +32,7 @@ export const executeSimulationTransaction = async (
   data: string,
   blockNumber: number,
   ethereumNode: EthereumNode
-): PromiseResult<string | void> => {
+): PromiseResult<string> => {
   try {
     return await retryWithTimeout(
       async () => {
@@ -117,7 +117,7 @@ export const getOnChainProfileDetails = async (
   currentPublicationId: string;
   dispatcherAddress: string;
   ownerOfAddress: string;
-} | void> => {
+}> => {
   // Create a new Multicall instance
   const multicall = new Multicall({
     nodeUrl: ethereumNode.nodeUrl,
@@ -266,7 +266,7 @@ export const getLensPubCount = async (
   profileId: string,
   blockNumber: number,
   ethereumNode: EthereumNode
-): PromiseResult<BigNumber | void> => {
+): PromiseResult<BigNumber> => {
   const encodedData = DAlensHubInterface.encodeFunctionData('getPubCount', [profileId]);
 
   try {

--- a/src/input-output/db.ts
+++ b/src/input-output/db.ts
@@ -8,6 +8,7 @@ import {
 import { BlockInfo } from '../evm/ethereum';
 import { failedProofsPath, lensDAPath, pathResolver } from './paths';
 import { TxValidatedResult } from './tx-validated-results';
+import { invariant } from '../utils/invariant';
 
 let db: Level | undefined;
 
@@ -23,7 +24,7 @@ export enum DbReference {
  * Starts the LevelDB database.
  */
 export const startDb = async (): Promise<void> => {
-  if (db) return;
+  invariant(!db, 'Database already started');
 
   const path = await pathResolver();
 
@@ -55,7 +56,8 @@ export const startDb = async (): Promise<void> => {
  * @param key - The key of the item to be deleted.
  */
 export const deleteDb = (key: string): Promise<void> => {
-  if (!db) return Promise.resolve();
+  invariant(db, 'Database not started');
+
   return db.del(key);
 };
 
@@ -65,7 +67,8 @@ export const deleteDb = (key: string): Promise<void> => {
  * @returns The transaction if it exists, null otherwise.
  */
 export const getTxDb = async (txId: string): Promise<TxValidatedResult | null> => {
-  if (!db) return null;
+  invariant(db, 'Database not started');
+
   try {
     const result = await db.get(`${DbReference.tx}:${txId}`);
     return JSON.parse(result) as TxValidatedResult;
@@ -81,7 +84,8 @@ export const getTxDb = async (txId: string): Promise<TxValidatedResult | null> =
  * @param result - The result of the transaction.
  */
 export const saveTxDb = async (txId: string, result: TxValidatedResult): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     await db.put(`${DbReference.tx}:${txId}`, JSON.stringify(result));
   } catch (error) {
@@ -96,7 +100,8 @@ export const saveTxDb = async (txId: string, result: TxValidatedResult): Promise
  * @returns The block if it exists, null otherwise.
  */
 export const getBlockDb = async (blockNumber: number): Promise<BlockInfo | null> => {
-  if (!db) return null;
+  invariant(db, 'Database not started');
+
   try {
     const result = await db.get(`${DbReference.block}:${blockNumber}`);
     return JSON.parse(result) as BlockInfo;
@@ -111,7 +116,8 @@ export const getBlockDb = async (blockNumber: number): Promise<BlockInfo | null>
  * @param block - The block to save.
  */
 export const saveBlockDb = async (block: BlockInfo): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     await db.put(`${DbReference.block}:${block.number}`, JSON.stringify(block));
   } catch (error) {
@@ -125,7 +131,8 @@ export const saveBlockDb = async (block: BlockInfo): Promise<void> => {
  * @returns The last end cursor.
  */
 export const getLastEndCursorDb = async (): Promise<string | null> => {
-  if (!db) return null;
+  invariant(db, 'Database not started');
+
   try {
     return await db.get(DbReference.cursor);
   } catch (e) {
@@ -139,7 +146,8 @@ export const getLastEndCursorDb = async (): Promise<string | null> => {
  * @throws Throws an error if the database is not available.
  */
 export const saveEndCursorDb = async (cursor: string): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     await db.put(DbReference.cursor, cursor);
   } catch (error) {
@@ -151,7 +159,8 @@ export const saveEndCursorDb = async (cursor: string): Promise<void> => {
  *  Gets the total checked count from the database.
  */
 export const getTotalCheckedCountDb = async (): Promise<number> => {
-  if (!db) return 0;
+  invariant(db, 'Database not started');
+
   try {
     const result = await db.get(`${DbReference.tx}:totalCheckedCount`);
     if (result) {
@@ -169,7 +178,8 @@ export const getTotalCheckedCountDb = async (): Promise<number> => {
  * @param checked The checked count to add to current total
  */
 export const saveTotalCheckedCountDb = async (checked: number): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     const currentCount = (await getTotalCheckedCountDb()) || 0;
     await db.put(`${DbReference.tx}:totalCheckedCount`, (currentCount + checked).toString());
@@ -188,7 +198,8 @@ export const saveTxDAMetadataDb = async (
   txId: string,
   publication: DAStructurePublication<DAEventType, PublicationTypedData>
 ): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     await db.put(`${DbReference.tx_da_metadata}:${txId}`, JSON.stringify(publication));
   } catch (error) {
@@ -204,7 +215,8 @@ export const saveTxDAMetadataDb = async (
 export const getTxDAMetadataDb = async (
   txId: string
 ): Promise<DAStructurePublication<DAEventType, PublicationTypedData> | null> => {
-  if (!db) return null;
+  invariant(db, 'Database not started');
+
   try {
     const result = await db.get(`${DbReference.tx_da_metadata}:${txId}`);
     return JSON.parse(result) as DAStructurePublication<DAEventType, PublicationTypedData>;
@@ -223,7 +235,8 @@ export const saveTxTimestampProofsMetadataDb = async (
   txId: string,
   proofs: DATimestampProofsResponse
 ): Promise<void> => {
-  if (!db) return;
+  invariant(db, 'Database not started');
+
   try {
     await db.put(`${DbReference.tx_timestamp_proof_metadata}:${txId}`, JSON.stringify(proofs));
   } catch (error) {
@@ -239,7 +252,8 @@ export const saveTxTimestampProofsMetadataDb = async (
 export const getTxTimestampProofsMetadataDb = async (
   txId: string
 ): Promise<DATimestampProofsResponse | null> => {
-  if (!db) return null;
+  invariant(db, 'Database not started');
+
   try {
     const result = await db.get(`${DbReference.tx_timestamp_proof_metadata}:${txId}`);
     return JSON.parse(result) as DATimestampProofsResponse;

--- a/src/input-output/paths.ts
+++ b/src/input-output/paths.ts
@@ -1,14 +1,8 @@
-import { isNativeNode } from '../common/helpers';
-
 export type PathType = {
   join(...paths: string[]): string;
 };
 let _path: PathType | undefined;
 export const pathResolver = async (): Promise<PathType> => {
-  if (!isNativeNode()) {
-    throw new Error('`path`- This function is only available in native node');
-  }
-
   if (_path) return Promise.resolve(_path);
 
   const pathImport = await import('path');
@@ -18,10 +12,6 @@ export const pathResolver = async (): Promise<PathType> => {
 
 let lensDAPathCache: string | undefined;
 export const lensDAPath = async (): Promise<string> => {
-  if (!isNativeNode()) {
-    throw new Error('`lensDAPath`- This function is only available in native node');
-  }
-
   if (lensDAPathCache) return Promise.resolve(lensDAPathCache);
 
   const path = await pathResolver();
@@ -31,10 +21,6 @@ export const lensDAPath = async (): Promise<string> => {
 
 let failedProofsPathCache: string | undefined;
 export const failedProofsPath = async (): Promise<string> => {
-  if (!isNativeNode()) {
-    throw new Error('`failedProofsPath`- This function is only available in native node');
-  }
-
   if (failedProofsPathCache) return Promise.resolve(failedProofsPathCache);
 
   const path = await pathResolver();

--- a/src/input-output/post-with-timeout.ts
+++ b/src/input-output/post-with-timeout.ts
@@ -1,29 +1,19 @@
-import axios from 'axios';
 import { curly } from 'node-libcurl';
-import { isNativeNode } from '../common/helpers';
 
 export const postWithTimeout = async <TResponse, TBody>(
   url: string,
   body: TBody
 ): Promise<TResponse> => {
-  if (isNativeNode()) {
-    const { statusCode, data } = await curly.post(url, {
-      postFields: JSON.stringify(body),
-      httpHeader: ['Content-Type: application/json'],
-      timeout: 5000,
-      curlyResponseBodyParser: false,
-    });
+  const { statusCode, data } = await curly.post(url, {
+    postFields: JSON.stringify(body),
+    httpHeader: ['Content-Type: application/json'],
+    timeout: 5000,
+    curlyResponseBodyParser: false,
+  });
 
-    if (statusCode !== 200) {
-      throw new Error(`postWithTimeout: ${statusCode} - ${data.toString()}`);
-    }
-
-    return JSON.parse(data.toString()) as TResponse;
-  } else {
-    const response = await axios.post(url, JSON.stringify(body), {
-      timeout: 5000,
-    });
-
-    return response.data as TResponse;
+  if (statusCode !== 200) {
+    throw new Error(`postWithTimeout: ${statusCode} - ${data.toString()}`);
   }
+
+  return JSON.parse(data.toString()) as TResponse;
 };

--- a/src/proofs/check-da-proof.ts
+++ b/src/proofs/check-da-proof.ts
@@ -53,7 +53,7 @@ export const checkDAProofWithMetadata = (
   ethereumNode: EthereumNode,
   options: CheckDASubmissionOptions = getDefaultCheckDASubmissionOptions
 ): PromiseWithContextResult<
-  DAStructurePublication<DAEventType, PublicationTypedData> | void,
+  DAStructurePublication<DAEventType, PublicationTypedData>,
   DAStructurePublication<DAEventType, PublicationTypedData>
 > => {
   return checker.checkDAProofWithMetadata(

--- a/src/proofs/da-proof-checker.ts
+++ b/src/proofs/da-proof-checker.ts
@@ -7,7 +7,6 @@ import {
   PromiseWithContextResult,
   PromiseWithContextResultOrNull,
   success,
-  successWithContext,
 } from '../data-availability-models/da-result';
 import { DAActionTypes } from '../data-availability-models/data-availability-action-types';
 import {
@@ -102,7 +101,7 @@ export class DaProofChecker {
     ethereumNode: EthereumNode,
     options: CheckDASubmissionOptions = getDefaultCheckDASubmissionOptions
   ): PromiseWithContextResult<
-    DAStructurePublication<DAEventType, PublicationTypedData> | void,
+    DAStructurePublication<DAEventType, PublicationTypedData>,
     DAStructurePublication<DAEventType, PublicationTypedData>
   > => {
     if (!options.byPassDb) {
@@ -224,7 +223,7 @@ export class DaProofChecker {
     ethereumNode: EthereumNode,
     { log, byPassDb, verifyPointer }: CheckDASubmissionOptions
   ): PromiseWithContextResult<
-    DAStructurePublication<DAEventType, PublicationTypedData> | void,
+    DAStructurePublication<DAEventType, PublicationTypedData>,
     DAStructurePublication<DAEventType, PublicationTypedData>
   > => {
     if (!daPublication.signature) {
@@ -269,7 +268,7 @@ export class DaProofChecker {
     );
 
     if (validateBlockResult.isFailure()) {
-      return failureWithContext(validateBlockResult.failure!, daPublication);
+      return failureWithContext(validateBlockResult.failure, daPublication);
     }
 
     log('event timestamp matches up the on chain block timestamp');
@@ -281,7 +280,7 @@ export class DaProofChecker {
     });
 
     if (daResult.isFailure()) {
-      return failureWithContext(daResult.failure!, daPublication);
+      return failureWithContext(daResult.failure, daPublication);
     }
 
     if (!isValidPublicationId(daPublication)) {
@@ -292,7 +291,7 @@ export class DaProofChecker {
       );
     }
 
-    return successWithContext(daPublication);
+    return success(daPublication);
   };
 
   /**
@@ -366,7 +365,7 @@ export class DaProofChecker {
   private getBlockRange = async (
     blockNumbers: number[],
     ethereumNode: EthereumNode
-  ): PromiseResult<BlockInfo[] | void> => {
+  ): PromiseResult<BlockInfo[]> => {
     try {
       const blocks = await this.gateway.getBlockRange(blockNumbers, ethereumNode);
 
@@ -397,10 +396,10 @@ export class DaProofChecker {
       const blocksResult = await this.getBlockRange(blockNumbers, ethereumNode);
 
       if (blocksResult.isFailure()) {
-        return failure(blocksResult.failure!);
+        return failure(blocksResult.failure);
       }
 
-      const blocks = blocksResult.successResult!;
+      const blocks = blocksResult.successResult;
       log(
         'blocks',
         blocks.map((c) => ({ time: c.timestamp * 1000, blockNumber: c.number }))
@@ -505,7 +504,7 @@ export class DaProofChecker {
     txId: string,
     log: LogFunctionType
   ): PromiseWithContextResultOrNull<
-    DAStructurePublication<DAEventType, PublicationTypedData> | void,
+    DAStructurePublication<DAEventType, PublicationTypedData>,
     DAStructurePublication<DAEventType, PublicationTypedData>
   > => {
     // Check if the transaction ID exists in the database
@@ -516,7 +515,7 @@ export class DaProofChecker {
       log('Already checked submission');
 
       if (cacheResult.success) {
-        return successWithContext(cacheResult.dataAvailabilityResult);
+        return success(cacheResult.dataAvailabilityResult);
       }
 
       return failureWithContext(

--- a/src/proofs/publications/comment/index.ts
+++ b/src/proofs/publications/comment/index.ts
@@ -117,10 +117,10 @@ export const checkDAComment = async (
   );
 
   if (whoSignedResult.isFailure()) {
-    return failure(whoSignedResult.failure!);
+    return failure(whoSignedResult.failure);
   }
 
-  const whoSigned = whoSignedResult.successResult!;
+  const whoSigned = whoSignedResult.successResult;
 
   log('who signed', whoSigned);
 
@@ -131,10 +131,10 @@ export const checkDAComment = async (
     ethereumNode
   );
   if (chainProfileDetailsResult.isFailure()) {
-    return failure(chainProfileDetailsResult.failure!);
+    return failure(chainProfileDetailsResult.failure);
   }
 
-  const details = chainProfileDetailsResult.successResult!;
+  const details = chainProfileDetailsResult.successResult;
 
   if (details.sigNonce !== typedData.value.nonce) {
     log('nonce mismatch', { expected: details.sigNonce, actual: typedData.value.nonce });

--- a/src/proofs/publications/mirror/index.ts
+++ b/src/proofs/publications/mirror/index.ts
@@ -115,10 +115,10 @@ export const checkDAMirror = async (
   );
 
   if (whoSignedResult.isFailure()) {
-    return failure(whoSignedResult.failure!);
+    return failure(whoSignedResult.failure);
   }
 
-  const whoSigned = whoSignedResult.successResult!;
+  const whoSigned = whoSignedResult.successResult;
 
   log('who signed', whoSigned);
 
@@ -130,10 +130,10 @@ export const checkDAMirror = async (
   );
 
   if (chainProfileDetailsResult.isFailure()) {
-    return failure(chainProfileDetailsResult.failure!);
+    return failure(chainProfileDetailsResult.failure);
   }
 
-  const details = chainProfileDetailsResult.successResult!;
+  const details = chainProfileDetailsResult.successResult;
 
   if (details.sigNonce !== typedData.value.nonce) {
     return failure(ClaimableValidatorError.PUBLICATION_NONCE_INVALID);

--- a/src/proofs/publications/publication.base.ts
+++ b/src/proofs/publications/publication.base.ts
@@ -22,7 +22,7 @@ export const whoSignedTypedData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: Record<string, any>,
   signature: SignatureLike
-): PromiseResult<string | void> => {
+): PromiseResult<string> => {
   try {
     const address = utils.verifyTypedData(domain, types, value, signature);
     return Promise.resolve(success(address));

--- a/src/utils/invariant.ts
+++ b/src/utils/invariant.ts
@@ -1,0 +1,19 @@
+export class InvariantError extends Error {
+  constructor(message: string) {
+    super(`InvariantError: ${message}`);
+  }
+}
+
+type Invariant = (condition: unknown, message: string) => asserts condition;
+
+/**
+ * Asserts that the given condition is truthy
+ *
+ * @param condition - Either truthy or falsy value
+ * @param message - An error message
+ */
+export const invariant: Invariant = (condition: unknown, message: string): asserts condition => {
+  if (!condition) {
+    throw new InvariantError(message);
+  }
+};


### PR DESCRIPTION
In this PR
- the DA result is now well-typed so no need to use non-null assertion operator, as we can see it caught a couple of inconsistencies in the returned types
- given that client is now a node.js agnostic we don't need any more `isNativeNode` function 
- given the above database now has invariant checks when called when in a wrong state 

Possible changes that i postponed to avoid breaking changes
- inconsistent naming inside `DAResult`, `successResult` vs `failure`, can be something like `value, failure` or `success, failure`.