### PR TITLE
Add stable dockerfile, Render blueprint, and relevant docs

### DIFF
--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -14,5 +14,5 @@ FROM base as runtime
 # Install stable version of momoka
 RUN pnpm add -g @lens-protocol/momoka
 
-# Run using the default shell, this is important to infer the $NODE_URL env variable
-CMD ["sh", "-c", "momoka --node $NODE_URL --environment=POLYGON --concurrency=100 --fromHead=true"]
+# Run using the default shell, this is important to infer the environment variables
+CMD ["sh", "-c", "momoka --node $NODE_URL --environment=$ENVIRONMENT --concurrency=$CONCURRENCY --fromHead=true"]

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -1,0 +1,18 @@
+FROM node:18-alpine AS base
+
+# Install pnpm through corepack
+RUN apk update
+RUN apk add --no-cache libc6-compat
+RUN corepack enable
+RUN corepack prepare pnpm@latest --activate
+
+# Specify a path for pnpm global root
+ENV PNPM_HOME=/usr/local/bin
+
+FROM base as runtime
+
+# Install stable version of momoka
+RUN pnpm add -g @lens-protocol/momoka
+
+# Run using the default shell, this is important to infer the $NODE_URL env variable
+CMD ["sh", "-c", "momoka --node $NODE_URL --environment=POLYGON --concurrency=100 --fromHead=true"]

--- a/README.md
+++ b/README.md
@@ -1633,7 +1633,7 @@ By default it will not resync all the data, it just start verifying from this po
 
 You can use the `Dockerfile.stable` file to set up a container which will run the latest stable release on Momoka from `npm`. The Dockerfile assumes running on the `POLYGON` environment, and sets concurrency to 100. You can change those if necessary. 
 
-A `NODE_URL` environment variable is required for it to work, which you can set however you'd like depending on how and where you're running the Docker container.
+A few environment variables are required for it to work, which you can set however you'd like depending on how and where you're running the Docker container. Specifically, you need to set `NODE_URL`, `ENVIRONMENT`, and `CONCURRENCY` environment variables.
 
 > NOTE: A `render.yaml` IaC blueprint is also provided which runs `Dockerfile.stable`. If you'd like to use [Render](https://render.com) for hosting your Momoka verifier, you can easily deploy it there by using the Render Blueprint. See their docs on [Infrastructure as Code](https://render.com/docs/infrastructure-as-code) to see how.
 

--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,10 @@ The default concurrency is 100, which typically requires a paid archive node. If
 
 ## Running straight out the box
 
+Currently, you have two options to run it directly. Either by using the npm `momoka` package, or through Docker.
+
+### Running from npm
+
 You can install it globally: 
 
 ```bash
@@ -1624,6 +1628,14 @@ $ npx @lens-protocol/momoka --node 'YOUR_NODE' --environment='MUMBAI|POLYGON' --
 ```
 
 By default it will not resync all the data, it just start verifying from this point onwards unless you add the parameter `--resync=true` which will start from block 0 and resync all the data.
+
+### Running from Docker
+
+You can use the `Dockerfile.stable` file to set up a container which will run the latest stable release on Momoka from `npm`. The Dockerfile assumes running on the `POLYGON` environment, and sets concurrency to 100. You can change those if necessary. 
+
+A `NODE_URL` environment variable is required for it to work, which you can set however you'd like depending on how and where you're running the Docker container.
+
+> NOTE: A `render.yaml` IaC blueprint is also provided which runs `Dockerfile.stable`. If you'd like to use [Render](https://render.com) for hosting your Momoka verifier, you can easily deploy it there by using the Render Blueprint. See their docs on [Infrastructure as Code](https://render.com/docs/infrastructure-as-code) to see how.
 
 ### Parameter meanings
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,5 @@
+services:
+  - type: worker
+    name: momoka
+    env: docker
+    dockerfilePath: ./Dockerfile.stable


### PR DESCRIPTION
Based on the quick conversation [here](https://twitter.com/devjoshstevens/status/1652349374662426626):

- Added `Dockerfile.stable` which fetches and runs latest Momoka release from npm
- Added `render.yaml` IaC blueprint to allow easy deployments to Render.com's servers
- Added steps in the documentation to explain these two files and how to run them