### PR TITLE
Reexports missing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,31 +153,61 @@ We will show you a few examples of the `DA` metadata and then explain each field
 ```js
 {
   signature:'0x87866d620636f62aa3930d8c48be37dac77f96f30a9e06748491934fef75e7884a193d59fc486da3ea35f991bbd37a04ea4997e47f191d626ad2b601e3cc57a71c',
-  dataAvailabilityId: '951a2a24-46fd-4306-8c31-46a8318a905e',
-  type: DAActionTypes.POST_CREATED,
-  timestampProofs: {
-    type: DAProvider.BUNDLR,
-    hashPrefix: '1',
-    response: {
+      dataAvailabilityId
+:
+  '951a2a24-46fd-4306-8c31-46a8318a905e',
+    type
+:
+  MomokaActionTypes.POST_CREATED,
+    timestampProofs
+:
+  {
+    type: MomokaProvider.BUNDLR,
+      hashPrefix
+  :
+    '1',
+      response
+  :
+    {
       id: 'f7_YMkEqiALN9PCtK5LXxFDlc3EEi20-DWl57KxDMbw',
-      timestamp: 1674736509185,
-      version: '1.0.0',
-      public:
-        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-      signature:
-        'Requv25_byuhK_k0JPz2tjKLhmqUv1XGt4My88utf8AHpl8awJKPMUQV3LJIQABMXf9ZsM2RZNiPhKEilkefGD-fTqkZZI5ybHooP8hc-lx2mAdM0XfCw-SC-yhdDU3OoOat7bwVy0HvOJm8xc6HpqgdbnTotX3LuPAo_xEV5GxrB5giK1IY8ZBJEsIjZw6okSzEStfmm94zAG44SmtTDXJk0IpeBpQiiZks63quZkPETGR9nfYl9-5D4UjQZHsx1eqV_9Pa4vYMOnTXD5LB8ysi2C576QjJAFICEZtRF2rXyZm1yfWBY8ODrnoZx-RBB5pqAwqrwA4DBI_UBHmbB7lL_3DK4911bZbC03T1KUw5QZn6eWjnoyxIv_UG9B3Bht0UDPIgGXA2tKeUsdrrh2JPAImZIYXEhC5ZWqn-K4TZa586sGwpQVfHFvCuCA-9X6GspXKDqlqbys6sZk70OOhM4827JIs9dw_Hw8rwsPsGIJjP99x2iOnyH8FQynbW8TCnGQcsO7Xevj-1PGnIAsXqQO6E9_NkYAf8LSfsilY63ZhVNPgLnSS2BAR-28SpHW4GjXtN_nVzE1CoLmL3nczMqHTiZ-xalo_enYg0Ydx-ZqHF7cPrB5rQmR_uB_7zPKK5WgStxwVjHRBJ8MLxmW0Sylzf9K6IwwFy50klQHY',
-      deadlineHeight: 1106524,
-      block: 1106524,
-      validatorSignatures: [],
-    },
-  },
+        timestamp
+    :
+      1674736509185,
+        version
+    :
+      '1.0.0',
+        public
+    :
+      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+        signature
+    :
+      'Requv25_byuhK_k0JPz2tjKLhmqUv1XGt4My88utf8AHpl8awJKPMUQV3LJIQABMXf9ZsM2RZNiPhKEilkefGD-fTqkZZI5ybHooP8hc-lx2mAdM0XfCw-SC-yhdDU3OoOat7bwVy0HvOJm8xc6HpqgdbnTotX3LuPAo_xEV5GxrB5giK1IY8ZBJEsIjZw6okSzEStfmm94zAG44SmtTDXJk0IpeBpQiiZks63quZkPETGR9nfYl9-5D4UjQZHsx1eqV_9Pa4vYMOnTXD5LB8ysi2C576QjJAFICEZtRF2rXyZm1yfWBY8ODrnoZx-RBB5pqAwqrwA4DBI_UBHmbB7lL_3DK4911bZbC03T1KUw5QZn6eWjnoyxIv_UG9B3Bht0UDPIgGXA2tKeUsdrrh2JPAImZIYXEhC5ZWqn-K4TZa586sGwpQVfHFvCuCA-9X6GspXKDqlqbys6sZk70OOhM4827JIs9dw_Hw8rwsPsGIJjP99x2iOnyH8FQynbW8TCnGQcsO7Xevj-1PGnIAsXqQO6E9_NkYAf8LSfsilY63ZhVNPgLnSS2BAR-28SpHW4GjXtN_nVzE1CoLmL3nczMqHTiZ-xalo_enYg0Ydx-ZqHF7cPrB5rQmR_uB_7zPKK5WgStxwVjHRBJ8MLxmW0Sylzf9K6IwwFy50klQHY',
+        deadlineHeight
+    :
+      1106524,
+        block
+    :
+      1106524,
+        validatorSignatures
+    :
+      [],
+    }
+  ,
+  }
+,
   chainProofs: {
     thisPublication: {
       signature:
         '0xa3a969bd1ecdf7ca416340b513fd751df446b922809bd05f25509a98223b69594e4d0e5c27ce01111f80dd2df8ffd5f1af75bd6d663f55c4186ef773da2168ac1c',
-      signedByDelegate: false,
-      signatureDeadline: 1674736509,
-      typedData: {
+          signedByDelegate
+    :
+      false,
+        signatureDeadline
+    :
+      1674736509,
+        typedData
+    :
+      {
         types: {
           PostWithSig: [
             {
@@ -213,40 +243,86 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        },
+        }
+      ,
         domain: {
           name: 'Lens Protocol Profiles',
-          version: '1',
-          chainId: 80001,
-          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        },
+            version
+        :
+          '1',
+            chainId
+        :
+          80001,
+            verifyingContract
+        :
+          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        }
+      ,
         value: {
           profileId: '0x18',
-          contentURI: 'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
-          collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-          collectModuleInitData: '0x',
-          referenceModule: '0x0000000000000000000000000000000000000000',
-          referenceModuleInitData: '0x',
-          nonce: 243,
-          deadline: 1674736509,
-        },
-      },
+            contentURI
+        :
+          'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
+            collectModule
+        :
+          '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+            collectModuleInitData
+        :
+          '0x',
+            referenceModule
+        :
+          '0x0000000000000000000000000000000000000000',
+            referenceModuleInitData
+        :
+          '0x',
+            nonce
+        :
+          243,
+            deadline
+        :
+          1674736509,
+        }
+      ,
+      }
+    ,
       blockHash: '0x43f670549e740c8b2b7b56967b8a24a546b734c83e05ba20a515faddddc7c345',
-      blockNumber: 31429670,
-      blockTimestamp: 1674736509,
-    },
+        blockNumber
+    :
+      31429670,
+        blockTimestamp
+    :
+      1674736509,
+    }
+  ,
     pointer: null,
-  },
+  }
+,
   publicationId: '0x18-0x3a-DA-951a2a24',
-  event: {
+    event
+:
+  {
     profileId: '0x18',
-    pubId: '0x3a',
-    contentURI: 'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
-    collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-    collectModuleReturnData: '0x',
-    referenceModule: '0x0000000000000000000000000000000000000000',
-    referenceModuleReturnData: '0x',
-    timestamp: 1674736509,
+      pubId
+  :
+    '0x3a',
+      contentURI
+  :
+    'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
+      collectModule
+  :
+    '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+      collectModuleReturnData
+  :
+    '0x',
+      referenceModule
+  :
+    '0x0000000000000000000000000000000000000000',
+      referenceModuleReturnData
+  :
+    '0x',
+      timestamp
+  :
+    1674736509,
   }
 }
 ```
@@ -361,31 +437,61 @@ We will show you a few examples of the `DA` metadata and then explain each field
 {
   signature:
     '0xcd9824d89bd3b237ed1230cf914630d756cae83904d835a1e85d37c11dbfab5e42c1f02042469ab29a3ccbd428c9a64576ad77f5876130b9c2bd49e0a83e9b7c1c',
-  dataAvailabilityId: '9a0b1d2b-e36e-48fc-87b4-b5f3f509b494',
-  type: DAActionTypes.COMMENT_CREATED,
-  timestampProofs: {
-    type: DAProvider.BUNDLR,
-    hashPrefix: '1',
-    response: {
+      dataAvailabilityId
+:
+  '9a0b1d2b-e36e-48fc-87b4-b5f3f509b494',
+    type
+:
+  MomokaActionTypes.COMMENT_CREATED,
+    timestampProofs
+:
+  {
+    type: MomokaProvider.BUNDLR,
+      hashPrefix
+  :
+    '1',
+      response
+  :
+    {
       id: 'xtVsUj5j1T4T86IQlJk2u-KubGD5oKIXOJQlU3KyGR0',
-      timestamp: 1674747795383,
-      version: '1.0.0',
-      public:
-        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-      signature:
-        'TZh1F7z14pbuHq7IBlHqnhT4PXEa2dQngiL-iHEXot3-w_ScVLyN9naCeuHvAP4mialS62YPucToy4o1UQlMEtTYS2i6C0rPap32xGi2yDA6AtzURf-xELI33em-mr9QIEuOph34t0yRLn3_Bl0n-AV4jyjVSgHdYjUT0vNZx3TbRkBi_v0PgJHDYkyezP_NrZgTomEe_VZmBgozc0J9zzK6atbIdsPnHYDbY3qzTujJEwogVQa311lNZvVe2ND6MR_0EUyVVW0esin6dyYEIPPCrjlFwMMgaoW4vBbGd1d11cRGopYgNvcX_0EuwAWYGwi8XW_GNGyrk4Df14VnOXAuP4NKd5oia820Be1vqwuAs3ubWX0OQ7CttOgohO9ns7CjYg9DVIwY5-AuJd2wAK6eI09fot-lTNVwtMVBvyxQ4GWaYspMcqkpysOY-5ow0wFp7K4Ad1FI4NO71cbEZQWD8ou08_A5Gd2a6qZF2fb7IJKka0aim26N858faf1nqViZfL-aym-AW60ydNav8inrTxVTMXml61WeG4KwlQXDrdoWkEquLB-1mJ-_519ozgy0QjSbyctp4LjpDpdp-yiJvzfweMFVRIKxarVB9Vvc0NFhyllE8sZud8zLBZ7wo7GG_1wijCJaICo-iD_FK97ZegnhotGLzeDC-KqY2vQ',
-      deadlineHeight: 1106619,
-      block: 1106619,
-      validatorSignatures: [],
-    },
-  },
+        timestamp
+    :
+      1674747795383,
+        version
+    :
+      '1.0.0',
+        public
+    :
+      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+        signature
+    :
+      'TZh1F7z14pbuHq7IBlHqnhT4PXEa2dQngiL-iHEXot3-w_ScVLyN9naCeuHvAP4mialS62YPucToy4o1UQlMEtTYS2i6C0rPap32xGi2yDA6AtzURf-xELI33em-mr9QIEuOph34t0yRLn3_Bl0n-AV4jyjVSgHdYjUT0vNZx3TbRkBi_v0PgJHDYkyezP_NrZgTomEe_VZmBgozc0J9zzK6atbIdsPnHYDbY3qzTujJEwogVQa311lNZvVe2ND6MR_0EUyVVW0esin6dyYEIPPCrjlFwMMgaoW4vBbGd1d11cRGopYgNvcX_0EuwAWYGwi8XW_GNGyrk4Df14VnOXAuP4NKd5oia820Be1vqwuAs3ubWX0OQ7CttOgohO9ns7CjYg9DVIwY5-AuJd2wAK6eI09fot-lTNVwtMVBvyxQ4GWaYspMcqkpysOY-5ow0wFp7K4Ad1FI4NO71cbEZQWD8ou08_A5Gd2a6qZF2fb7IJKka0aim26N858faf1nqViZfL-aym-AW60ydNav8inrTxVTMXml61WeG4KwlQXDrdoWkEquLB-1mJ-_519ozgy0QjSbyctp4LjpDpdp-yiJvzfweMFVRIKxarVB9Vvc0NFhyllE8sZud8zLBZ7wo7GG_1wijCJaICo-iD_FK97ZegnhotGLzeDC-KqY2vQ',
+        deadlineHeight
+    :
+      1106619,
+        block
+    :
+      1106619,
+        validatorSignatures
+    :
+      [],
+    }
+  ,
+  }
+,
   chainProofs: {
     thisPublication: {
       signature:
         '0x5156c7e636be61a305373df811d8444b7715448e2bde3fe69d388f301270d83d72796c5ef58283c1a9d32b37033a6b567a32addb78aedef0957fbf56956cd2351b',
-      signedByDelegate: false,
-      signatureDeadline: 1674747793,
-      typedData: {
+          signedByDelegate
+    :
+      false,
+        signatureDeadline
+    :
+      1674747793,
+        typedData
+    :
+      {
         types: {
           CommentWithSig: [
             {
@@ -433,49 +539,110 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        },
+        }
+      ,
         domain: {
           name: 'Lens Protocol Profiles',
-          version: '1',
-          chainId: 80001,
-          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        },
+            version
+        :
+          '1',
+            chainId
+        :
+          80001,
+            verifyingContract
+        :
+          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        }
+      ,
         value: {
           profileId: '0x18',
-          profileIdPointed: '0x18',
-          pubIdPointed: '0x3a',
-          contentURI: 'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
-          referenceModule: '0x0000000000000000000000000000000000000000',
-          collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-          collectModuleInitData: '0x',
-          referenceModuleInitData: '0x',
-          referenceModuleData: '0x',
-          nonce: 243,
-          deadline: 1674747793,
-        },
-      },
+            profileIdPointed
+        :
+          '0x18',
+            pubIdPointed
+        :
+          '0x3a',
+            contentURI
+        :
+          'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
+            referenceModule
+        :
+          '0x0000000000000000000000000000000000000000',
+            collectModule
+        :
+          '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+            collectModuleInitData
+        :
+          '0x',
+            referenceModuleInitData
+        :
+          '0x',
+            referenceModuleData
+        :
+          '0x',
+            nonce
+        :
+          243,
+            deadline
+        :
+          1674747793,
+        }
+      ,
+      }
+    ,
       blockHash: '0x11b2e5b1b7fa87c3a30d10d6f0416f5cb540c30ac7ae4b1be5058d9b5031e172',
-      blockNumber: 31434975,
-      blockTimestamp: 1674747793,
-    },
+        blockNumber
+    :
+      31434975,
+        blockTimestamp
+    :
+      1674747793,
+    }
+  ,
     pointer: {
       location: 'ar://TEoFkgD0m-LLQkfViuCTKfCLK_xpSxzPUNoMjBLnvlI',
-      type: DAPublicationPointerType.ON_DA,
-    },
-  },
+        type
+    :
+      DAPublicationPointerType.ON_DA,
+    }
+  ,
+  }
+,
   publicationId: '0x18-0x3a-DA-9a0b1d2b',
-  event: {
+    event
+:
+  {
     profileId: '0x18',
-    pubId: '0x3a',
-    contentURI: 'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
-    profileIdPointed: '0x18',
-    pubIdPointed: '0x3a',
-    referenceModuleData: '0x',
-    collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-    collectModuleReturnData: '0x',
-    referenceModule: '0x0000000000000000000000000000000000000000',
-    referenceModuleReturnData: '0x',
-    timestamp: 1674747793,
+      pubId
+  :
+    '0x3a',
+      contentURI
+  :
+    'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
+      profileIdPointed
+  :
+    '0x18',
+      pubIdPointed
+  :
+    '0x3a',
+      referenceModuleData
+  :
+    '0x',
+      collectModule
+  :
+    '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+      collectModuleReturnData
+  :
+    '0x',
+      referenceModule
+  :
+    '0x0000000000000000000000000000000000000000',
+      referenceModuleReturnData
+  :
+    '0x',
+      timestamp
+  :
+    1674747793,
   }
 }
 ```
@@ -624,37 +791,74 @@ We will show you a few examples of the `DA` metadata and then explain each field
 {
   signature:
     '0x1683ef107f09a291ebbe8f4bfc4f628ff9be10f661d0d18048c31a8b1ca981d948ef12c591e5d762e952bc287e57838b031a6451f2b8a58cfc5cedb565c742661b',
-  dataAvailabilityId: '538ca9c4-682b-41d2-9b8a-52ede43728d7',
-  type: DAActionTypes.MIRROR_CREATED,
-  timestampProofs: {
-    type: DAProvider.BUNDLR,
-    hashPrefix: '1',
-    response: {
+      dataAvailabilityId
+:
+  '538ca9c4-682b-41d2-9b8a-52ede43728d7',
+    type
+:
+  MomokaActionTypes.MIRROR_CREATED,
+    timestampProofs
+:
+  {
+    type: MomokaProvider.BUNDLR,
+      hashPrefix
+  :
+    '1',
+      response
+  :
+    {
       id: 'zdkCXuVzawg3KipWCRVK2fo-yIUoj5IMuIYyFPGA55o',
-      timestamp: 1674748125246,
-      version: '1.0.0',
-      public:
-        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-      signature:
-        'IJjhzO0D4ioq9Gc0mghnxvOIkrZdmrqkc_UpMkL9R-qulzvkZ_LY4QRQxP-rNAm-ZIoN3Jep9zefjTaRRvU6mhc6hKZaMWC4XvWW_IXl5TZH1eOfq0JENjoRoZ75IdwicJXtc9c7obeNs84hXqlNHJXUoQfC2mEjkqiRpK_Vz43Hxn-3ZkrNvNEM1cpbl5hJU3UP0iCQnJQPiTgiojnhTBgRoIEpLQBFdoF1IRXUH4J4TBCMoX5MzG5PUj_FJkJiYX_SM0iaiDi0y-6-IsvOu1o32UWVgmDa-PbTrd6kGuDdd3Ys4HHyjGbS4NGkbu-coMW7RdkCegowgrXvzDoVxG0pVKoMK7ndOfZJJlud3jonqcDDI0vESSVdt_DDMOjkqdHiyWdVWcDlS0TnToIdwuOgaHDgpoqFjPUd5GwE40QFix6QflbxfcFqleru9eDY4_hufxMYEWK3DiSN6QIe6jQg6-9ZLFvD4Chr_bxL48UkfwDx-Y7EZo5tb6uzwzEqAfXEb5ITyzVrEgo1sXEDKKkkNQ7C5Hq2mryWKRXHUtXkKErI1P_bNRp2GXumO30uwZfpsMcAtFPCsPMnm1j4aqhFjcpVk9HpFPa6DcCuX6U8T3MODbJbNPxFc_Pdt5wcLo6EcLEnnQTIvQEIj_aQvh__rh79d6XHckI1TL-9gAM',
-      deadlineHeight: 1106621,
-      block: 1106621,
-      validatorSignatures: [],
-    },
-  },
+        timestamp
+    :
+      1674748125246,
+        version
+    :
+      '1.0.0',
+        public
+    :
+      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+        signature
+    :
+      'IJjhzO0D4ioq9Gc0mghnxvOIkrZdmrqkc_UpMkL9R-qulzvkZ_LY4QRQxP-rNAm-ZIoN3Jep9zefjTaRRvU6mhc6hKZaMWC4XvWW_IXl5TZH1eOfq0JENjoRoZ75IdwicJXtc9c7obeNs84hXqlNHJXUoQfC2mEjkqiRpK_Vz43Hxn-3ZkrNvNEM1cpbl5hJU3UP0iCQnJQPiTgiojnhTBgRoIEpLQBFdoF1IRXUH4J4TBCMoX5MzG5PUj_FJkJiYX_SM0iaiDi0y-6-IsvOu1o32UWVgmDa-PbTrd6kGuDdd3Ys4HHyjGbS4NGkbu-coMW7RdkCegowgrXvzDoVxG0pVKoMK7ndOfZJJlud3jonqcDDI0vESSVdt_DDMOjkqdHiyWdVWcDlS0TnToIdwuOgaHDgpoqFjPUd5GwE40QFix6QflbxfcFqleru9eDY4_hufxMYEWK3DiSN6QIe6jQg6-9ZLFvD4Chr_bxL48UkfwDx-Y7EZo5tb6uzwzEqAfXEb5ITyzVrEgo1sXEDKKkkNQ7C5Hq2mryWKRXHUtXkKErI1P_bNRp2GXumO30uwZfpsMcAtFPCsPMnm1j4aqhFjcpVk9HpFPa6DcCuX6U8T3MODbJbNPxFc_Pdt5wcLo6EcLEnnQTIvQEIj_aQvh__rh79d6XHckI1TL-9gAM',
+        deadlineHeight
+    :
+      1106621,
+        block
+    :
+      1106621,
+        validatorSignatures
+    :
+      [],
+    }
+  ,
+  }
+,
   chainProofs: {
     thisPublication: {
       signature:
         '0x59cb0d34ef20e93e4073cadec0d05eb8ef9a6af4b55d7ddea099666f83509d193e554c4149856ddb36ac3a4601c7f4e12fc413e016b6d4b314846eb3222b2e9b1b',
-      signedByDelegate: false,
-      signatureDeadline: 1674748123,
-      typedData: {
+          signedByDelegate
+    :
+      false,
+        signatureDeadline
+    :
+      1674748123,
+        typedData
+    :
+      {
         domain: {
           name: 'Lens Protocol Profiles',
-          version: '1',
-          chainId: 80001,
-          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        },
+            version
+        :
+          '1',
+            chainId
+        :
+          80001,
+            verifyingContract
+        :
+          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        }
+      ,
         types: {
           MirrorWithSig: [
             {
@@ -690,37 +894,79 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        },
+        }
+      ,
         value: {
           profileId: '0x18',
-          profileIdPointed: '0x18',
-          pubIdPointed: '0x3a',
-          referenceModuleData: '0x',
-          referenceModule: '0x0000000000000000000000000000000000000000',
-          referenceModuleInitData: '0x',
-          deadline: 1674748123,
-          nonce: 243,
-        },
-      },
+            profileIdPointed
+        :
+          '0x18',
+            pubIdPointed
+        :
+          '0x3a',
+            referenceModuleData
+        :
+          '0x',
+            referenceModule
+        :
+          '0x0000000000000000000000000000000000000000',
+            referenceModuleInitData
+        :
+          '0x',
+            deadline
+        :
+          1674748123,
+            nonce
+        :
+          243,
+        }
+      ,
+      }
+    ,
       blockHash: '0x0fb258841acaf93b998028bfc7296b840a80cdc76ffd999d5101bc72cf2daf78',
-      blockNumber: 31435129,
-      blockTimestamp: 1674748123,
-    },
+        blockNumber
+    :
+      31435129,
+        blockTimestamp
+    :
+      1674748123,
+    }
+  ,
     pointer: {
       location: 'ar://ff9CtLecXt1HBFBR-SoRz8tLjPjBo8gxbmy7kmFpJl4',
-      type: DAPublicationPointerType.ON_DA,
-    },
-  },
+        type
+    :
+      DAPublicationPointerType.ON_DA,
+    }
+  ,
+  }
+,
   publicationId: '0x18-0x3a-DA-538ca9c4',
-  event: {
+    event
+:
+  {
     profileId: '0x18',
-    pubId: '0x3a',
-    profileIdPointed: '0x18',
-    pubIdPointed: '0x3a',
-    referenceModuleData: '0x',
-    referenceModule: '0x0000000000000000000000000000000000000000',
-    referenceModuleReturnData: '0x',
-    timestamp: 1674748123,
+      pubId
+  :
+    '0x3a',
+      profileIdPointed
+  :
+    '0x18',
+      pubIdPointed
+  :
+    '0x3a',
+      referenceModuleData
+  :
+    '0x',
+      referenceModule
+  :
+    '0x0000000000000000000000000000000000000000',
+      referenceModuleReturnData
+  :
+    '0x',
+      timestamp
+  :
+    1674748123,
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -153,61 +153,31 @@ We will show you a few examples of the `DA` metadata and then explain each field
 ```js
 {
   signature:'0x87866d620636f62aa3930d8c48be37dac77f96f30a9e06748491934fef75e7884a193d59fc486da3ea35f991bbd37a04ea4997e47f191d626ad2b601e3cc57a71c',
-      dataAvailabilityId
-:
-  '951a2a24-46fd-4306-8c31-46a8318a905e',
-    type
-:
-  MomokaActionTypes.POST_CREATED,
-    timestampProofs
-:
-  {
+  dataAvailabilityId: '951a2a24-46fd-4306-8c31-46a8318a905e',
+  type: MomokaActionTypes.POST_CREATED,
+  timestampProofs: {
     type: MomokaProvider.BUNDLR,
-      hashPrefix
-  :
-    '1',
-      response
-  :
-    {
+    hashPrefix: '1',
+    response: {
       id: 'f7_YMkEqiALN9PCtK5LXxFDlc3EEi20-DWl57KxDMbw',
-        timestamp
-    :
-      1674736509185,
-        version
-    :
-      '1.0.0',
-        public
-    :
-      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-        signature
-    :
-      'Requv25_byuhK_k0JPz2tjKLhmqUv1XGt4My88utf8AHpl8awJKPMUQV3LJIQABMXf9ZsM2RZNiPhKEilkefGD-fTqkZZI5ybHooP8hc-lx2mAdM0XfCw-SC-yhdDU3OoOat7bwVy0HvOJm8xc6HpqgdbnTotX3LuPAo_xEV5GxrB5giK1IY8ZBJEsIjZw6okSzEStfmm94zAG44SmtTDXJk0IpeBpQiiZks63quZkPETGR9nfYl9-5D4UjQZHsx1eqV_9Pa4vYMOnTXD5LB8ysi2C576QjJAFICEZtRF2rXyZm1yfWBY8ODrnoZx-RBB5pqAwqrwA4DBI_UBHmbB7lL_3DK4911bZbC03T1KUw5QZn6eWjnoyxIv_UG9B3Bht0UDPIgGXA2tKeUsdrrh2JPAImZIYXEhC5ZWqn-K4TZa586sGwpQVfHFvCuCA-9X6GspXKDqlqbys6sZk70OOhM4827JIs9dw_Hw8rwsPsGIJjP99x2iOnyH8FQynbW8TCnGQcsO7Xevj-1PGnIAsXqQO6E9_NkYAf8LSfsilY63ZhVNPgLnSS2BAR-28SpHW4GjXtN_nVzE1CoLmL3nczMqHTiZ-xalo_enYg0Ydx-ZqHF7cPrB5rQmR_uB_7zPKK5WgStxwVjHRBJ8MLxmW0Sylzf9K6IwwFy50klQHY',
-        deadlineHeight
-    :
-      1106524,
-        block
-    :
-      1106524,
-        validatorSignatures
-    :
-      [],
-    }
-  ,
-  }
-,
+      timestamp: 1674736509185,
+      version: '1.0.0',
+      public:
+        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+      signature:
+        'Requv25_byuhK_k0JPz2tjKLhmqUv1XGt4My88utf8AHpl8awJKPMUQV3LJIQABMXf9ZsM2RZNiPhKEilkefGD-fTqkZZI5ybHooP8hc-lx2mAdM0XfCw-SC-yhdDU3OoOat7bwVy0HvOJm8xc6HpqgdbnTotX3LuPAo_xEV5GxrB5giK1IY8ZBJEsIjZw6okSzEStfmm94zAG44SmtTDXJk0IpeBpQiiZks63quZkPETGR9nfYl9-5D4UjQZHsx1eqV_9Pa4vYMOnTXD5LB8ysi2C576QjJAFICEZtRF2rXyZm1yfWBY8ODrnoZx-RBB5pqAwqrwA4DBI_UBHmbB7lL_3DK4911bZbC03T1KUw5QZn6eWjnoyxIv_UG9B3Bht0UDPIgGXA2tKeUsdrrh2JPAImZIYXEhC5ZWqn-K4TZa586sGwpQVfHFvCuCA-9X6GspXKDqlqbys6sZk70OOhM4827JIs9dw_Hw8rwsPsGIJjP99x2iOnyH8FQynbW8TCnGQcsO7Xevj-1PGnIAsXqQO6E9_NkYAf8LSfsilY63ZhVNPgLnSS2BAR-28SpHW4GjXtN_nVzE1CoLmL3nczMqHTiZ-xalo_enYg0Ydx-ZqHF7cPrB5rQmR_uB_7zPKK5WgStxwVjHRBJ8MLxmW0Sylzf9K6IwwFy50klQHY',
+      deadlineHeight: 1106524,
+      block: 1106524,
+      validatorSignatures: [],
+    },
+  },
   chainProofs: {
     thisPublication: {
       signature:
         '0xa3a969bd1ecdf7ca416340b513fd751df446b922809bd05f25509a98223b69594e4d0e5c27ce01111f80dd2df8ffd5f1af75bd6d663f55c4186ef773da2168ac1c',
-          signedByDelegate
-    :
-      false,
-        signatureDeadline
-    :
-      1674736509,
-        typedData
-    :
-      {
+      signedByDelegate: false,
+      signatureDeadline: 1674736509,
+      typedData: {
         types: {
           PostWithSig: [
             {
@@ -243,86 +213,40 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        }
-      ,
+        },
         domain: {
           name: 'Lens Protocol Profiles',
-            version
-        :
-          '1',
-            chainId
-        :
-          80001,
-            verifyingContract
-        :
-          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        }
-      ,
+          version: '1',
+          chainId: 80001,
+          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        },
         value: {
           profileId: '0x18',
-            contentURI
-        :
-          'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
-            collectModule
-        :
-          '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-            collectModuleInitData
-        :
-          '0x',
-            referenceModule
-        :
-          '0x0000000000000000000000000000000000000000',
-            referenceModuleInitData
-        :
-          '0x',
-            nonce
-        :
-          243,
-            deadline
-        :
-          1674736509,
-        }
-      ,
-      }
-    ,
+          contentURI: 'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
+          collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+          collectModuleInitData: '0x',
+          referenceModule: '0x0000000000000000000000000000000000000000',
+          referenceModuleInitData: '0x',
+          nonce: 243,
+          deadline: 1674736509,
+        },
+      },
       blockHash: '0x43f670549e740c8b2b7b56967b8a24a546b734c83e05ba20a515faddddc7c345',
-        blockNumber
-    :
-      31429670,
-        blockTimestamp
-    :
-      1674736509,
-    }
-  ,
+      blockNumber: 31429670,
+      blockTimestamp: 1674736509,
+    },
     pointer: null,
-  }
-,
+  },
   publicationId: '0x18-0x3a-DA-951a2a24',
-    event
-:
-  {
+  event: {
     profileId: '0x18',
-      pubId
-  :
-    '0x3a',
-      contentURI
-  :
-    'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
-      collectModule
-  :
-    '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-      collectModuleReturnData
-  :
-    '0x',
-      referenceModule
-  :
-    '0x0000000000000000000000000000000000000000',
-      referenceModuleReturnData
-  :
-    '0x',
-      timestamp
-  :
-    1674736509,
+    pubId: '0x3a',
+    contentURI: 'ar://NKrOBI6zMU4mnptAGYvirARSvBAU-nkCITQ5-LZkEco',
+    collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+    collectModuleReturnData: '0x',
+    referenceModule: '0x0000000000000000000000000000000000000000',
+    referenceModuleReturnData: '0x',
+    timestamp: 1674736509,
   }
 }
 ```
@@ -437,61 +361,31 @@ We will show you a few examples of the `DA` metadata and then explain each field
 {
   signature:
     '0xcd9824d89bd3b237ed1230cf914630d756cae83904d835a1e85d37c11dbfab5e42c1f02042469ab29a3ccbd428c9a64576ad77f5876130b9c2bd49e0a83e9b7c1c',
-      dataAvailabilityId
-:
-  '9a0b1d2b-e36e-48fc-87b4-b5f3f509b494',
-    type
-:
-  MomokaActionTypes.COMMENT_CREATED,
-    timestampProofs
-:
-  {
+  dataAvailabilityId: '9a0b1d2b-e36e-48fc-87b4-b5f3f509b494',
+  type: MomokaActionTypes.COMMENT_CREATED,
+  timestampProofs: {
     type: MomokaProvider.BUNDLR,
-      hashPrefix
-  :
-    '1',
-      response
-  :
-    {
+    hashPrefix: '1',
+    response: {
       id: 'xtVsUj5j1T4T86IQlJk2u-KubGD5oKIXOJQlU3KyGR0',
-        timestamp
-    :
-      1674747795383,
-        version
-    :
-      '1.0.0',
-        public
-    :
-      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-        signature
-    :
-      'TZh1F7z14pbuHq7IBlHqnhT4PXEa2dQngiL-iHEXot3-w_ScVLyN9naCeuHvAP4mialS62YPucToy4o1UQlMEtTYS2i6C0rPap32xGi2yDA6AtzURf-xELI33em-mr9QIEuOph34t0yRLn3_Bl0n-AV4jyjVSgHdYjUT0vNZx3TbRkBi_v0PgJHDYkyezP_NrZgTomEe_VZmBgozc0J9zzK6atbIdsPnHYDbY3qzTujJEwogVQa311lNZvVe2ND6MR_0EUyVVW0esin6dyYEIPPCrjlFwMMgaoW4vBbGd1d11cRGopYgNvcX_0EuwAWYGwi8XW_GNGyrk4Df14VnOXAuP4NKd5oia820Be1vqwuAs3ubWX0OQ7CttOgohO9ns7CjYg9DVIwY5-AuJd2wAK6eI09fot-lTNVwtMVBvyxQ4GWaYspMcqkpysOY-5ow0wFp7K4Ad1FI4NO71cbEZQWD8ou08_A5Gd2a6qZF2fb7IJKka0aim26N858faf1nqViZfL-aym-AW60ydNav8inrTxVTMXml61WeG4KwlQXDrdoWkEquLB-1mJ-_519ozgy0QjSbyctp4LjpDpdp-yiJvzfweMFVRIKxarVB9Vvc0NFhyllE8sZud8zLBZ7wo7GG_1wijCJaICo-iD_FK97ZegnhotGLzeDC-KqY2vQ',
-        deadlineHeight
-    :
-      1106619,
-        block
-    :
-      1106619,
-        validatorSignatures
-    :
-      [],
-    }
-  ,
-  }
-,
+      timestamp: 1674747795383,
+      version: '1.0.0',
+      public:
+        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+      signature:
+        'TZh1F7z14pbuHq7IBlHqnhT4PXEa2dQngiL-iHEXot3-w_ScVLyN9naCeuHvAP4mialS62YPucToy4o1UQlMEtTYS2i6C0rPap32xGi2yDA6AtzURf-xELI33em-mr9QIEuOph34t0yRLn3_Bl0n-AV4jyjVSgHdYjUT0vNZx3TbRkBi_v0PgJHDYkyezP_NrZgTomEe_VZmBgozc0J9zzK6atbIdsPnHYDbY3qzTujJEwogVQa311lNZvVe2ND6MR_0EUyVVW0esin6dyYEIPPCrjlFwMMgaoW4vBbGd1d11cRGopYgNvcX_0EuwAWYGwi8XW_GNGyrk4Df14VnOXAuP4NKd5oia820Be1vqwuAs3ubWX0OQ7CttOgohO9ns7CjYg9DVIwY5-AuJd2wAK6eI09fot-lTNVwtMVBvyxQ4GWaYspMcqkpysOY-5ow0wFp7K4Ad1FI4NO71cbEZQWD8ou08_A5Gd2a6qZF2fb7IJKka0aim26N858faf1nqViZfL-aym-AW60ydNav8inrTxVTMXml61WeG4KwlQXDrdoWkEquLB-1mJ-_519ozgy0QjSbyctp4LjpDpdp-yiJvzfweMFVRIKxarVB9Vvc0NFhyllE8sZud8zLBZ7wo7GG_1wijCJaICo-iD_FK97ZegnhotGLzeDC-KqY2vQ',
+      deadlineHeight: 1106619,
+      block: 1106619,
+      validatorSignatures: [],
+    },
+  },
   chainProofs: {
     thisPublication: {
       signature:
         '0x5156c7e636be61a305373df811d8444b7715448e2bde3fe69d388f301270d83d72796c5ef58283c1a9d32b37033a6b567a32addb78aedef0957fbf56956cd2351b',
-          signedByDelegate
-    :
-      false,
-        signatureDeadline
-    :
-      1674747793,
-        typedData
-    :
-      {
+      signedByDelegate: false,
+      signatureDeadline: 1674747793,
+      typedData: {
         types: {
           CommentWithSig: [
             {
@@ -539,110 +433,49 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        }
-      ,
+        },
         domain: {
           name: 'Lens Protocol Profiles',
-            version
-        :
-          '1',
-            chainId
-        :
-          80001,
-            verifyingContract
-        :
-          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        }
-      ,
+          version: '1',
+          chainId: 80001,
+          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        },
         value: {
           profileId: '0x18',
-            profileIdPointed
-        :
-          '0x18',
-            pubIdPointed
-        :
-          '0x3a',
-            contentURI
-        :
-          'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
-            referenceModule
-        :
-          '0x0000000000000000000000000000000000000000',
-            collectModule
-        :
-          '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-            collectModuleInitData
-        :
-          '0x',
-            referenceModuleInitData
-        :
-          '0x',
-            referenceModuleData
-        :
-          '0x',
-            nonce
-        :
-          243,
-            deadline
-        :
-          1674747793,
-        }
-      ,
-      }
-    ,
+          profileIdPointed: '0x18',
+          pubIdPointed: '0x3a',
+          contentURI: 'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
+          referenceModule: '0x0000000000000000000000000000000000000000',
+          collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+          collectModuleInitData: '0x',
+          referenceModuleInitData: '0x',
+          referenceModuleData: '0x',
+          nonce: 243,
+          deadline: 1674747793,
+        },
+      },
       blockHash: '0x11b2e5b1b7fa87c3a30d10d6f0416f5cb540c30ac7ae4b1be5058d9b5031e172',
-        blockNumber
-    :
-      31434975,
-        blockTimestamp
-    :
-      1674747793,
-    }
-  ,
+      blockNumber: 31434975,
+      blockTimestamp: 1674747793,
+    },
     pointer: {
       location: 'ar://TEoFkgD0m-LLQkfViuCTKfCLK_xpSxzPUNoMjBLnvlI',
-        type
-    :
-      DAPublicationPointerType.ON_DA,
-    }
-  ,
-  }
-,
+      type: DAPublicationPointerType.ON_DA,
+    },
+  },
   publicationId: '0x18-0x3a-DA-9a0b1d2b',
-    event
-:
-  {
+  event: {
     profileId: '0x18',
-      pubId
-  :
-    '0x3a',
-      contentURI
-  :
-    'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
-      profileIdPointed
-  :
-    '0x18',
-      pubIdPointed
-  :
-    '0x3a',
-      referenceModuleData
-  :
-    '0x',
-      collectModule
-  :
-    '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
-      collectModuleReturnData
-  :
-    '0x',
-      referenceModule
-  :
-    '0x0000000000000000000000000000000000000000',
-      referenceModuleReturnData
-  :
-    '0x',
-      timestamp
-  :
-    1674747793,
+    pubId: '0x3a',
+    contentURI: 'ar://5JNO_BIyW7sD8crn1PPt3SrCZUKF9t-f8Rs13Zh1w1Q',
+    profileIdPointed: '0x18',
+    pubIdPointed: '0x3a',
+    referenceModuleData: '0x',
+    collectModule: '0x5E70fFD2C6D04d65C3abeBa64E93082cfA348dF8',
+    collectModuleReturnData: '0x',
+    referenceModule: '0x0000000000000000000000000000000000000000',
+    referenceModuleReturnData: '0x',
+    timestamp: 1674747793,
   }
 }
 ```
@@ -791,74 +624,37 @@ We will show you a few examples of the `DA` metadata and then explain each field
 {
   signature:
     '0x1683ef107f09a291ebbe8f4bfc4f628ff9be10f661d0d18048c31a8b1ca981d948ef12c591e5d762e952bc287e57838b031a6451f2b8a58cfc5cedb565c742661b',
-      dataAvailabilityId
-:
-  '538ca9c4-682b-41d2-9b8a-52ede43728d7',
-    type
-:
-  MomokaActionTypes.MIRROR_CREATED,
-    timestampProofs
-:
-  {
+  dataAvailabilityId: '538ca9c4-682b-41d2-9b8a-52ede43728d7',
+  type: MomokaActionTypes.MIRROR_CREATED,
+  timestampProofs: {
     type: MomokaProvider.BUNDLR,
-      hashPrefix
-  :
-    '1',
-      response
-  :
-    {
+    hashPrefix: '1',
+    response: {
       id: 'zdkCXuVzawg3KipWCRVK2fo-yIUoj5IMuIYyFPGA55o',
-        timestamp
-    :
-      1674748125246,
-        version
-    :
-      '1.0.0',
-        public
-    :
-      'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
-        signature
-    :
-      'IJjhzO0D4ioq9Gc0mghnxvOIkrZdmrqkc_UpMkL9R-qulzvkZ_LY4QRQxP-rNAm-ZIoN3Jep9zefjTaRRvU6mhc6hKZaMWC4XvWW_IXl5TZH1eOfq0JENjoRoZ75IdwicJXtc9c7obeNs84hXqlNHJXUoQfC2mEjkqiRpK_Vz43Hxn-3ZkrNvNEM1cpbl5hJU3UP0iCQnJQPiTgiojnhTBgRoIEpLQBFdoF1IRXUH4J4TBCMoX5MzG5PUj_FJkJiYX_SM0iaiDi0y-6-IsvOu1o32UWVgmDa-PbTrd6kGuDdd3Ys4HHyjGbS4NGkbu-coMW7RdkCegowgrXvzDoVxG0pVKoMK7ndOfZJJlud3jonqcDDI0vESSVdt_DDMOjkqdHiyWdVWcDlS0TnToIdwuOgaHDgpoqFjPUd5GwE40QFix6QflbxfcFqleru9eDY4_hufxMYEWK3DiSN6QIe6jQg6-9ZLFvD4Chr_bxL48UkfwDx-Y7EZo5tb6uzwzEqAfXEb5ITyzVrEgo1sXEDKKkkNQ7C5Hq2mryWKRXHUtXkKErI1P_bNRp2GXumO30uwZfpsMcAtFPCsPMnm1j4aqhFjcpVk9HpFPa6DcCuX6U8T3MODbJbNPxFc_Pdt5wcLo6EcLEnnQTIvQEIj_aQvh__rh79d6XHckI1TL-9gAM',
-        deadlineHeight
-    :
-      1106621,
-        block
-    :
-      1106621,
-        validatorSignatures
-    :
-      [],
-    }
-  ,
-  }
-,
+      timestamp: 1674748125246,
+      version: '1.0.0',
+      public:
+        'sq9JbppKLlAKtQwalfX5DagnGMlTirditXk7y4jgoeA7DEM0Z6cVPE5xMQ9kz_T9VppP6BFHtHyZCZODercEVWipzkr36tfQkR5EDGUQyLivdxUzbWgVkzw7D27PJEa4cd1Uy6r18rYLqERgbRvAZph5YJZmpSJk7r3MwnQquuktjvSpfCLFwSxP1w879-ss_JalM9ICzRi38henONio8gll6GV9-omrWwRMZer_15bspCK5txCwpY137nfKwKD5YBAuzxxcj424M7zlSHlsafBwaRwFbf8gHtW03iJER4lR4GxeY0WvnYaB3KDISHQp53a9nlbmiWO5WcHHYsR83OT2eJ0Pl3RWA-_imk_SNwGQTCjmA6tf_UVwL8HzYS2iyuu85b7iYK9ZQoh8nqbNC6qibICE4h9Fe3bN7AgitIe9XzCTOXDfMr4ahjC8kkqJ1z4zNAI6-Leei_Mgd8JtZh2vqFNZhXK0lSadFl_9Oh3AET7tUds2E7s-6zpRPd9oBZu6-kNuHDRJ6TQhZSwJ9ZO5HYsccb_G_1so72aXJymR9ggJgWr4J3bawAYYnqmvmzGklYOlE_5HVnMxf-UxpT7ztdsHbc9QEH6W2bzwxbpjTczEZs3JCCB3c-NewNHsj9PYM3b5tTlTNP9kNAwPZHWpt11t79LuNkNGt9LfOek',
+      signature:
+        'IJjhzO0D4ioq9Gc0mghnxvOIkrZdmrqkc_UpMkL9R-qulzvkZ_LY4QRQxP-rNAm-ZIoN3Jep9zefjTaRRvU6mhc6hKZaMWC4XvWW_IXl5TZH1eOfq0JENjoRoZ75IdwicJXtc9c7obeNs84hXqlNHJXUoQfC2mEjkqiRpK_Vz43Hxn-3ZkrNvNEM1cpbl5hJU3UP0iCQnJQPiTgiojnhTBgRoIEpLQBFdoF1IRXUH4J4TBCMoX5MzG5PUj_FJkJiYX_SM0iaiDi0y-6-IsvOu1o32UWVgmDa-PbTrd6kGuDdd3Ys4HHyjGbS4NGkbu-coMW7RdkCegowgrXvzDoVxG0pVKoMK7ndOfZJJlud3jonqcDDI0vESSVdt_DDMOjkqdHiyWdVWcDlS0TnToIdwuOgaHDgpoqFjPUd5GwE40QFix6QflbxfcFqleru9eDY4_hufxMYEWK3DiSN6QIe6jQg6-9ZLFvD4Chr_bxL48UkfwDx-Y7EZo5tb6uzwzEqAfXEb5ITyzVrEgo1sXEDKKkkNQ7C5Hq2mryWKRXHUtXkKErI1P_bNRp2GXumO30uwZfpsMcAtFPCsPMnm1j4aqhFjcpVk9HpFPa6DcCuX6U8T3MODbJbNPxFc_Pdt5wcLo6EcLEnnQTIvQEIj_aQvh__rh79d6XHckI1TL-9gAM',
+      deadlineHeight: 1106621,
+      block: 1106621,
+      validatorSignatures: [],
+    },
+  },
   chainProofs: {
     thisPublication: {
       signature:
         '0x59cb0d34ef20e93e4073cadec0d05eb8ef9a6af4b55d7ddea099666f83509d193e554c4149856ddb36ac3a4601c7f4e12fc413e016b6d4b314846eb3222b2e9b1b',
-          signedByDelegate
-    :
-      false,
-        signatureDeadline
-    :
-      1674748123,
-        typedData
-    :
-      {
+      signedByDelegate: false,
+      signatureDeadline: 1674748123,
+      typedData: {
         domain: {
           name: 'Lens Protocol Profiles',
-            version
-        :
-          '1',
-            chainId
-        :
-          80001,
-            verifyingContract
-        :
-          '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
-        }
-      ,
+          version: '1',
+          chainId: 80001,
+          verifyingContract: '0x60Ae865ee4C725cd04353b5AAb364553f56ceF82',
+        },
         types: {
           MirrorWithSig: [
             {
@@ -894,79 +690,37 @@ We will show you a few examples of the `DA` metadata and then explain each field
               type: 'uint256',
             },
           ],
-        }
-      ,
+        },
         value: {
           profileId: '0x18',
-            profileIdPointed
-        :
-          '0x18',
-            pubIdPointed
-        :
-          '0x3a',
-            referenceModuleData
-        :
-          '0x',
-            referenceModule
-        :
-          '0x0000000000000000000000000000000000000000',
-            referenceModuleInitData
-        :
-          '0x',
-            deadline
-        :
-          1674748123,
-            nonce
-        :
-          243,
-        }
-      ,
-      }
-    ,
+          profileIdPointed: '0x18',
+          pubIdPointed: '0x3a',
+          referenceModuleData: '0x',
+          referenceModule: '0x0000000000000000000000000000000000000000',
+          referenceModuleInitData: '0x',
+          deadline: 1674748123,
+          nonce: 243,
+        },
+      },
       blockHash: '0x0fb258841acaf93b998028bfc7296b840a80cdc76ffd999d5101bc72cf2daf78',
-        blockNumber
-    :
-      31435129,
-        blockTimestamp
-    :
-      1674748123,
-    }
-  ,
+      blockNumber: 31435129,
+      blockTimestamp: 1674748123,
+    },
     pointer: {
       location: 'ar://ff9CtLecXt1HBFBR-SoRz8tLjPjBo8gxbmy7kmFpJl4',
-        type
-    :
-      DAPublicationPointerType.ON_DA,
-    }
-  ,
-  }
-,
+      type: DAPublicationPointerType.ON_DA,
+    },
+  },
   publicationId: '0x18-0x3a-DA-538ca9c4',
-    event
-:
-  {
+  event: {
     profileId: '0x18',
-      pubId
-  :
-    '0x3a',
-      profileIdPointed
-  :
-    '0x18',
-      pubIdPointed
-  :
-    '0x3a',
-      referenceModuleData
-  :
-    '0x',
-      referenceModule
-  :
-    '0x0000000000000000000000000000000000000000',
-      referenceModuleReturnData
-  :
-    '0x',
-      timestamp
-  :
-    1674748123,
+    pubId: '0x3a',
+    profileIdPointed: '0x18',
+    pubIdPointed: '0x3a',
+    referenceModuleData: '0x',
+    referenceModule: '0x0000000000000000000000000000000000000000',
+    referenceModuleReturnData: '0x',
+    timestamp: 1674748123,
   }
 }
 ```

--- a/momoka-node/CHANGELOG.md
+++ b/momoka-node/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased - fill in any changes you do here!
 
 - feat: add support for lens v2 publications
+- fix: export MomokaProvider and MomokaActionTypes
 
 ## Features
 

--- a/momoka-node/src/__TESTS__/mocks/comment/comment-created-delegate-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/comment/comment-created-delegate-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import {
   DAPublicationPointerType,
   DAStructurePublication,
@@ -14,9 +14,9 @@ export const commentCreatedDelegateArweaveResponse: DAStructurePublication<
   signature:
     '0xd422257695bbc5cd9e75e128c864b1a498fa281673d91d972edafdcc8459fdef7f755343ebf5a39ab32189425df653d2c31b908d9f6142c41ae6b59b125804201b',
   dataAvailabilityId: '1f337269-6e83-4e91-94e0-7da2038d1a8b',
-  type: DAActionTypes.COMMENT_CREATED,
+  type: MomokaActionTypes.COMMENT_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'AkE_aGaF0V-gacWAZ8H5G9y79sidDOTKrpFGoMsrQcs',

--- a/momoka-node/src/__TESTS__/mocks/comment/comment-created-without-delegate-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/comment/comment-created-without-delegate-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import {
   DAPublicationPointerType,
   DAStructurePublication,
@@ -14,9 +14,9 @@ export const commentCreatedWithoutDelegateArweaveResponse: DAStructurePublicatio
   signature:
     '0xcd9824d89bd3b237ed1230cf914630d756cae83904d835a1e85d37c11dbfab5e42c1f02042469ab29a3ccbd428c9a64576ad77f5876130b9c2bd49e0a83e9b7c1c',
   dataAvailabilityId: '9a0b1d2b-e36e-48fc-87b4-b5f3f509b494',
-  type: DAActionTypes.COMMENT_CREATED,
+  type: MomokaActionTypes.COMMENT_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'xtVsUj5j1T4T86IQlJk2u-KubGD5oKIXOJQlU3KyGR0',

--- a/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-delegate-comment-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-delegate-comment-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import {
   DAPublicationPointerType,
   DAStructurePublication,
@@ -14,9 +14,9 @@ export const mirrorCreatedDelegateCommentArweaveResponse: DAStructurePublication
   signature:
     '0x9480369047ce27715600bdbf391dec6e4b62c36cd1840b5def450f78398ae2007f6b4c520343819bc2fe15a0e5835e4cfe577900522e8a526ae042e6186884961b',
   dataAvailabilityId: '1cc575ce-3c64-4ab5-bdb9-a13153b0afc1',
-  type: DAActionTypes.MIRROR_CREATED,
+  type: MomokaActionTypes.MIRROR_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 's-CnsDdnEn5aaz8pFKdq897bQUtiCmHY263zJrfQ5xA',

--- a/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-delegate-post-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-delegate-post-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import { CreateMirrorV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
 import {
   DAPublicationPointerType,
@@ -14,9 +14,9 @@ export const mirrorCreatedDelegatePostArweaveResponse: DAStructurePublication<
   signature:
     '0x11a14ad03435338c5548154119cf151f0b827ee4598130ad3220d0fb995c24c658d47bb3f5ac88368fd654b707d74a1d1116f08e86336ddef8351ddb537ace401b',
   dataAvailabilityId: '6534728f-e7d6-47b6-94d7-8608230c4928',
-  type: DAActionTypes.MIRROR_CREATED,
+  type: MomokaActionTypes.MIRROR_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'PX-Xd26m3pu_lkpeRzlBftrRAExFQOsLLEEL6eVPEoY',

--- a/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-without-delegate-comment-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-without-delegate-comment-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import { CreateMirrorV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
 import {
   DAPublicationPointerType,
@@ -14,9 +14,9 @@ export const mirrorCreatedWithoutDelegateCommentArweaveResponse: DAStructurePubl
   signature:
     '0x9a80809f6db6f28a96e14ec588125ceecf4824a65c2e7ca748f8de7fd1531c696cb119eb5027fc09d02c8eb64700e8d470302c328780a12767da3696d69d46d81c',
   dataAvailabilityId: 'b812eb36-30d8-4657-bd42-b239621b8696',
-  type: DAActionTypes.MIRROR_CREATED,
+  type: MomokaActionTypes.MIRROR_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'YfgVWKZ4jV19_IhFucPKIjjgyCJLcKfxH7Q1SUbRSWM',

--- a/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-without-delegate-post-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/mirror/mirror-created-without-delegate-post-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import { CreateMirrorV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
 import {
   DAPublicationPointerType,
@@ -14,9 +14,9 @@ export const mirrorCreatedWithoutDelegatePostArweaveResponse: DAStructurePublica
   signature:
     '0x1683ef107f09a291ebbe8f4bfc4f628ff9be10f661d0d18048c31a8b1ca981d948ef12c591e5d762e952bc287e57838b031a6451f2b8a58cfc5cedb565c742661b',
   dataAvailabilityId: '538ca9c4-682b-41d2-9b8a-52ede43728d7',
-  type: DAActionTypes.MIRROR_CREATED,
+  type: MomokaActionTypes.MIRROR_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'zdkCXuVzawg3KipWCRVK2fo-yIUoj5IMuIYyFPGA55o',

--- a/momoka-node/src/__TESTS__/mocks/post/post-created-delegate-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/post/post-created-delegate-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import { CreatePostV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
 import { DAStructurePublication } from '../../../data-availability-models/publications/data-availability-structure-publication';
 import { DAPostCreatedEventEmittedResponse } from '../../../data-availability-models/publications/data-availability-structure-publications-events';
@@ -11,9 +11,9 @@ export const postCreatedDelegateArweaveResponse: DAStructurePublication<
   signature:
     '0x42c63a72de7442c809a8db23f9994ff3c57b5a2101e8512102ea1238a78181903513c675ea35bd2e912f1a258dabe631fd22b3609e9edcd1a9df799c0ebc03621c',
   dataAvailabilityId: '68d40ddd-a9ae-4843-b9e8-50ed55e27488',
-  type: DAActionTypes.POST_CREATED,
+  type: MomokaActionTypes.POST_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'DMGovTZKvZkWCbhgm1mRNi3MrjMl9lJtQ-0ReW4j7Wc',

--- a/momoka-node/src/__TESTS__/mocks/post/post-created-without-delegate-arweave-response.mock.ts
+++ b/momoka-node/src/__TESTS__/mocks/post/post-created-without-delegate-arweave-response.mock.ts
@@ -1,5 +1,5 @@
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
-import { DAProvider } from '../../../data-availability-models/data-availability-provider';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaProvider } from '../../../data-availability-models/data-availability-provider';
 import { CreatePostV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
 import { DAStructurePublication } from '../../../data-availability-models/publications/data-availability-structure-publication';
 import { DAPostCreatedEventEmittedResponse } from '../../../data-availability-models/publications/data-availability-structure-publications-events';
@@ -11,9 +11,9 @@ export const postCreatedWithoutDelegateArweaveResponse: DAStructurePublication<
   signature:
     '0x87866d620636f62aa3930d8c48be37dac77f96f30a9e06748491934fef75e7884a193d59fc486da3ea35f991bbd37a04ea4997e47f191d626ad2b601e3cc57a71c',
   dataAvailabilityId: '951a2a24-46fd-4306-8c31-46a8318a905e',
-  type: DAActionTypes.POST_CREATED,
+  type: MomokaActionTypes.POST_CREATED,
   timestampProofs: {
-    type: DAProvider.BUNDLR,
+    type: MomokaProvider.BUNDLR,
     hashPrefix: '1',
     response: {
       id: 'f7_YMkEqiALN9PCtK5LXxFDlc3EEi20-DWl57KxDMbw',

--- a/momoka-node/src/data-availability-models/data-availability-action-types.ts
+++ b/momoka-node/src/data-availability-models/data-availability-action-types.ts
@@ -1,4 +1,4 @@
-export enum DAActionTypes {
+export enum MomokaActionTypes {
   POST_CREATED = 'POST_CREATED',
   COMMENT_CREATED = 'COMMENT_CREATED',
   MIRROR_CREATED = 'MIRROR_CREATED',

--- a/momoka-node/src/data-availability-models/data-availability-provider.ts
+++ b/momoka-node/src/data-availability-models/data-availability-provider.ts
@@ -1,3 +1,3 @@
-export enum DAProvider {
+export enum MomokaProvider {
   BUNDLR = 'BUNDLR',
 }

--- a/momoka-node/src/data-availability-models/data-availability-structure-base.ts
+++ b/momoka-node/src/data-availability-models/data-availability-structure-base.ts
@@ -1,4 +1,4 @@
-import { DAActionTypes } from './data-availability-action-types';
+import { MomokaActionTypes } from './data-availability-action-types';
 import { DATimestampProofs } from './data-availability-timestamp-proofs';
 
 export interface DAStructureBase {
@@ -15,7 +15,7 @@ export interface DAStructureBase {
   /**
    * The DA action type
    */
-  type: DAActionTypes;
+  type: MomokaActionTypes;
 
   /**
    * The timestamp proofs

--- a/momoka-node/src/index.ts
+++ b/momoka-node/src/index.ts
@@ -19,3 +19,5 @@ export {
   startDATrustingIndexing,
 } from './watchers/trusting-indexing.watcher';
 export { startDAVerifierNode } from './watchers/verifier.watcher';
+export { MomokaActionTypes } from './data-availability-models/data-availability-action-types';
+export { MomokaProvider } from './data-availability-models/data-availability-provider';

--- a/momoka-node/src/proofs/da-proof-checker.ts
+++ b/momoka-node/src/proofs/da-proof-checker.ts
@@ -8,7 +8,7 @@ import {
   failureWithContext,
   success,
 } from '../data-availability-models/da-result';
-import { DAActionTypes } from '../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../data-availability-models/data-availability-action-types';
 import {
   DAPublicationWithTimestampProofsBatchResult,
   DATimestampProofsResponse,
@@ -452,9 +452,9 @@ export class DaProofChecker {
     }
 
     switch (publicationVerifier.type) {
-      case DAActionTypes.POST_CREATED:
+      case MomokaActionTypes.POST_CREATED:
         return checkDAPost(publicationVerifier, checkOptions.log);
-      case DAActionTypes.COMMENT_CREATED:
+      case MomokaActionTypes.COMMENT_CREATED:
         return checkDAComment(
           publicationVerifier,
           checkOptions.verifyPointer,
@@ -462,7 +462,7 @@ export class DaProofChecker {
           checkOptions.log,
           this
         );
-      case DAActionTypes.MIRROR_CREATED:
+      case MomokaActionTypes.MIRROR_CREATED:
         return checkDAMirror(
           publicationVerifier,
           checkOptions.verifyPointer,
@@ -470,7 +470,7 @@ export class DaProofChecker {
           checkOptions.log,
           this
         );
-      case DAActionTypes.QUOTE_CREATED:
+      case MomokaActionTypes.QUOTE_CREATED:
         return checkDAQuote(
           publicationVerifier,
           checkOptions.verifyPointer,

--- a/momoka-node/src/proofs/publications/comment/da-comment-verifier-v1.ts
+++ b/momoka-node/src/proofs/publications/comment/da-comment-verifier-v1.ts
@@ -7,7 +7,7 @@ import { failure, PromiseResult, success } from '../../../data-availability-mode
 import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
 import { EMPTY_BYTE, EthereumNode } from '../../../evm/ethereum';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 
 export type DACommentPublicationV1 = DAStructurePublication<
   DACommentCreatedEventEmittedResponseV1,
@@ -18,13 +18,13 @@ export const isDACommentPublicationV1 = (
   daPublication: DAStructurePublication
 ): daPublication is DACommentPublicationV1 => {
   return (
-    daPublication.type === DAActionTypes.COMMENT_CREATED &&
+    daPublication.type === MomokaActionTypes.COMMENT_CREATED &&
     !('commentParams' in daPublication.event)
   );
 };
 
 export class DACommentVerifierV1 extends DAPublicationVerifierV1 {
-  public readonly type = DAActionTypes.COMMENT_CREATED;
+  public readonly type = MomokaActionTypes.COMMENT_CREATED;
 
   constructor(
     public readonly daPublication: DACommentPublicationV1,

--- a/momoka-node/src/proofs/publications/comment/da-comment-verifier-v2.ts
+++ b/momoka-node/src/proofs/publications/comment/da-comment-verifier-v2.ts
@@ -7,7 +7,7 @@ import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
 import { DAPublicationVerifierV2 } from '../da-publication-verifier-v2';
 import { generatePublicationId } from '../../utils';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 import { EMPTY_BYTE, EthereumNode } from '../../../evm/ethereum';
 import { arraysEqual } from '../../../utils/arrays-equal';
 
@@ -20,12 +20,13 @@ export const isDACommentPublicationV2 = (
   daPublication: DAStructurePublication
 ): daPublication is DACommentPublicationV2 => {
   return (
-    daPublication.type === DAActionTypes.COMMENT_CREATED && 'commentParams' in daPublication.event
+    daPublication.type === MomokaActionTypes.COMMENT_CREATED &&
+    'commentParams' in daPublication.event
   );
 };
 
 export class DACommentVerifierV2 extends DAPublicationVerifierV2 {
-  public readonly type = DAActionTypes.COMMENT_CREATED;
+  public readonly type = MomokaActionTypes.COMMENT_CREATED;
 
   constructor(
     public readonly daPublication: DACommentPublicationV2,

--- a/momoka-node/src/proofs/publications/create-da-publication-verifier.ts
+++ b/momoka-node/src/proofs/publications/create-da-publication-verifier.ts
@@ -1,5 +1,5 @@
 import { DAStructurePublication } from '../../data-availability-models/publications/data-availability-structure-publication';
-import { DAActionTypes } from '../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../data-availability-models/data-availability-action-types';
 import { DACommentVerifierV1, isDACommentPublicationV1 } from './comment/da-comment-verifier-v1';
 import { DACommentVerifierV2, isDACommentPublicationV2 } from './comment/da-comment-verifier-v2';
 import { LogFunctionType } from '../../common/logger';
@@ -27,7 +27,7 @@ export const createDAPublicationVerifier = (
   log: LogFunctionType
 ): PromiseResult<DAPublicationVerifier> => {
   switch (daPublication.type) {
-    case DAActionTypes.POST_CREATED:
+    case MomokaActionTypes.POST_CREATED:
       if (isDAPostPublicationV1(daPublication)) {
         log('verifying post v1');
         return Promise.resolve(success(new DAPostVerifierV1(daPublication, ethereumNode, log)));
@@ -42,7 +42,7 @@ export const createDAPublicationVerifier = (
       log('post was not recognized as v1 or v2');
 
       return Promise.resolve(failure(MomokaValidatorError.PUBLICATION_NOT_RECOGNIZED));
-    case DAActionTypes.COMMENT_CREATED:
+    case MomokaActionTypes.COMMENT_CREATED:
       if (isDACommentPublicationV1(daPublication)) {
         log('verifying comment v1');
 
@@ -58,7 +58,7 @@ export const createDAPublicationVerifier = (
       log('comment was not recognized as v1 or v2');
 
       return Promise.resolve(failure(MomokaValidatorError.PUBLICATION_NOT_RECOGNIZED));
-    case DAActionTypes.MIRROR_CREATED:
+    case MomokaActionTypes.MIRROR_CREATED:
       if (isDAMirrorPublicationV1(daPublication)) {
         log('verifying mirror v1');
 
@@ -73,7 +73,7 @@ export const createDAPublicationVerifier = (
       log('mirror was not recognized as v1 or v2');
 
       return Promise.resolve(failure(MomokaValidatorError.PUBLICATION_NOT_RECOGNIZED));
-    case DAActionTypes.QUOTE_CREATED:
+    case MomokaActionTypes.QUOTE_CREATED:
       if (isDAQuotePublicationV2(daPublication)) {
         log('verifying quote v2');
 

--- a/momoka-node/src/proofs/publications/mirror/da-mirror-verifier-v1.ts
+++ b/momoka-node/src/proofs/publications/mirror/da-mirror-verifier-v1.ts
@@ -7,7 +7,7 @@ import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
 import { EMPTY_BYTE, EthereumNode } from '../../../evm/ethereum';
 import { CreateMirrorV1EIP712TypedData } from '../../../data-availability-models/publications/data-availability-publication-typed-data';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 
 export type DAMirrorPublicationV1 = DAStructurePublication<
   DAMirrorCreatedEventEmittedResponseV1,
@@ -18,12 +18,13 @@ export const isDAMirrorPublicationV1 = (
   daPublication: DAStructurePublication
 ): daPublication is DAMirrorPublicationV1 => {
   return (
-    daPublication.type === DAActionTypes.MIRROR_CREATED && !('mirrorParams' in daPublication.event)
+    daPublication.type === MomokaActionTypes.MIRROR_CREATED &&
+    !('mirrorParams' in daPublication.event)
   );
 };
 
 export class DAMirrorVerifierV1 extends DAPublicationVerifierV1 {
-  public readonly type = DAActionTypes.MIRROR_CREATED;
+  public readonly type = MomokaActionTypes.MIRROR_CREATED;
 
   constructor(
     public readonly daPublication: DAMirrorPublicationV1,

--- a/momoka-node/src/proofs/publications/mirror/da-mirror-verifier-v2.ts
+++ b/momoka-node/src/proofs/publications/mirror/da-mirror-verifier-v2.ts
@@ -7,7 +7,7 @@ import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
 import { DAPublicationVerifierV2 } from '../da-publication-verifier-v2';
 import { generatePublicationId } from '../../utils';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 import { EMPTY_BYTE, EthereumNode } from '../../../evm/ethereum';
 import { arraysEqual } from '../../../utils/arrays-equal';
 
@@ -20,12 +20,12 @@ export const isDAMirrorPublicationV2 = (
   daPublication: DAStructurePublication
 ): daPublication is DAMirrorPublicationV2 => {
   return (
-    daPublication.type === DAActionTypes.MIRROR_CREATED && 'mirrorParams' in daPublication.event
+    daPublication.type === MomokaActionTypes.MIRROR_CREATED && 'mirrorParams' in daPublication.event
   );
 };
 
 export class DAMirrorVerifierV2 extends DAPublicationVerifierV2 {
-  public readonly type = DAActionTypes.MIRROR_CREATED;
+  public readonly type = MomokaActionTypes.MIRROR_CREATED;
 
   constructor(
     public readonly daPublication: DAMirrorPublicationV2,

--- a/momoka-node/src/proofs/publications/post/da-post-verifier-v1.ts
+++ b/momoka-node/src/proofs/publications/post/da-post-verifier-v1.ts
@@ -13,7 +13,7 @@ import {
   executeSimulationTransaction,
   parseSignature,
 } from '../../../evm/ethereum';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 import { PostWithSig_DispatcherRequest } from '../../../evm/abi-types/LensHubV1';
 
 export type DAPostPublicationV1 = DAStructurePublication<
@@ -25,12 +25,12 @@ export const isDAPostPublicationV1 = (
   daPublication: DAStructurePublication
 ): daPublication is DAPostPublicationV1 => {
   return (
-    daPublication.type === DAActionTypes.POST_CREATED && !('postParams' in daPublication.event)
+    daPublication.type === MomokaActionTypes.POST_CREATED && !('postParams' in daPublication.event)
   );
 };
 
 export class DAPostVerifierV1 extends DAPublicationVerifierV1 {
-  public readonly type = DAActionTypes.POST_CREATED;
+  public readonly type = MomokaActionTypes.POST_CREATED;
 
   constructor(
     public readonly daPublication: DAPostPublicationV1,

--- a/momoka-node/src/proofs/publications/post/da-post-verifier-v2.ts
+++ b/momoka-node/src/proofs/publications/post/da-post-verifier-v2.ts
@@ -5,7 +5,7 @@ import { LogFunctionType } from '../../../common/logger';
 import { failure, PromiseResult, success } from '../../../data-availability-models/da-result';
 import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 import {
   blockHashExists,
   EMPTY_BYTE,
@@ -27,11 +27,13 @@ export type DAPostPublicationV2 = DAStructurePublication<
 export const isDAPostPublicationV2 = (
   daPublication: DAStructurePublication
 ): daPublication is DAPostPublicationV2 => {
-  return daPublication.type === DAActionTypes.POST_CREATED && 'postParams' in daPublication.event;
+  return (
+    daPublication.type === MomokaActionTypes.POST_CREATED && 'postParams' in daPublication.event
+  );
 };
 
 export class DAPostVerifierV2 extends DAPublicationVerifierV2 {
-  public readonly type = DAActionTypes.POST_CREATED;
+  public readonly type = MomokaActionTypes.POST_CREATED;
 
   constructor(
     public readonly daPublication: DAPostPublicationV2,

--- a/momoka-node/src/proofs/publications/quote/da-quote-verifier-v2.ts
+++ b/momoka-node/src/proofs/publications/quote/da-quote-verifier-v2.ts
@@ -7,7 +7,7 @@ import { BigNumber } from 'ethers';
 import { MomokaValidatorError } from '../../../data-availability-models/validator-errors';
 import { DAPublicationVerifierV2 } from '../da-publication-verifier-v2';
 import { generatePublicationId } from '../../utils';
-import { DAActionTypes } from '../../../data-availability-models/data-availability-action-types';
+import { MomokaActionTypes } from '../../../data-availability-models/data-availability-action-types';
 import { EMPTY_BYTE, EthereumNode } from '../../../evm/ethereum';
 import { arraysEqual } from '../../../utils/arrays-equal';
 
@@ -19,11 +19,13 @@ export type DAQuotePublicationV2 = DAStructurePublication<
 export const isDAQuotePublicationV2 = (
   daPublication: DAStructurePublication
 ): daPublication is DAQuotePublicationV2 => {
-  return daPublication.type === DAActionTypes.QUOTE_CREATED && 'quoteParams' in daPublication.event;
+  return (
+    daPublication.type === MomokaActionTypes.QUOTE_CREATED && 'quoteParams' in daPublication.event
+  );
 };
 
 export class DAQuoteVerifierV2 extends DAPublicationVerifierV2 {
-  public readonly type = DAActionTypes.QUOTE_CREATED;
+  public readonly type = MomokaActionTypes.QUOTE_CREATED;
 
   constructor(
     public readonly daPublication: DAQuotePublicationV2,


### PR DESCRIPTION
Reexport `MomokaProvider` and `MomokaActionTypes`

We also need at some point to clean up the code from DA naming for consitency.